### PR TITLE
Common properties and converters

### DIFF
--- a/Source/Common/pom.xml
+++ b/Source/Common/pom.xml
@@ -11,6 +11,8 @@
     </parent>
 
     <artifactId>moose-common</artifactId>
+    <name>Moose Common Components</name>
+    <description>Common components that are used in multiple Moose Modules, to ensure that the they work and are configured properly together.</description>
 
     <dependencies>
         <dependency>

--- a/Source/Common/pom.xml
+++ b/Source/Common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dolittle.moose</groupId>
         <artifactId>moose-parent</artifactId>
-        <version>0.0.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/Source/Common/pom.xml
+++ b/Source/Common/pom.xml
@@ -10,12 +10,12 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>moose-controller</artifactId>
+    <artifactId>moose-common</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>io.dolittle.moose</groupId>
-            <artifactId>moose-common</artifactId>
+            <artifactId>moose-kubernetes</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/Source/Common/src/main/java/io/dolittle/moose/common/config/CommonConfig.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/config/CommonConfig.java
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package io.dolittle.moose.common.config;
 
 import org.springframework.context.annotation.ComponentScan;

--- a/Source/Common/src/main/java/io/dolittle/moose/common/config/CommonConfig.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/config/CommonConfig.java
@@ -1,0 +1,11 @@
+package io.dolittle.moose.common.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+  
+@Configuration
+@ComponentScan(basePackages = {"io.dolittle.moose.common", "io.dolittle.moose.kubernetes.config"})
+@PropertySource(value = {"classpath:common.properties"})
+public class CommonConfig {
+}

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/CommonProperties.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/CommonProperties.java
@@ -1,0 +1,11 @@
+package io.dolittle.moose.common.properties;
+
+import io.dolittle.moose.common.properties.ping.PingProperties;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+@Value
+@NonFinal
+public abstract class CommonProperties {
+    protected PingProperties ping;
+}

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/CommonProperties.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/CommonProperties.java
@@ -1,11 +1,14 @@
 package io.dolittle.moose.common.properties;
 
-import io.dolittle.moose.common.properties.ping.PingProperties;
+import io.dolittle.moose.common.properties.ping.PingIngressProperties;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 
+/**
+ * Defines common properties that are shared by multiple modules to ensure they are configured the same at runtime.
+ */
 @Value
 @NonFinal
 public abstract class CommonProperties {
-    protected PingProperties ping;
+    protected PingIngressProperties ping;
 }

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/CommonProperties.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/CommonProperties.java
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package io.dolittle.moose.common.properties;
 
 import io.dolittle.moose.common.properties.ping.PingIngressProperties;

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/AnnotationConverter.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/AnnotationConverter.java
@@ -1,0 +1,61 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.properties.converters;
+
+import java.util.regex.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import io.dolittle.moose.kubernetes.Annotation;
+
+/**
+ * A Spring {@link Converter} that converts {@link String} property values to {@link Annotation}.
+ */
+@Component
+@ConfigurationPropertiesBinding
+public class AnnotationConverter implements Converter<String, Annotation> {
+    private static Pattern pattern = Pattern.compile("^([a-zA-Z0-9\\-\\.]+\\/)?([a-zA-Z0-9]+)(:(.*))?$");
+
+    @Override
+    public Annotation convert(String source) {
+        if (source == null) {
+            throw new AnnotationPropertyIsInvalid("value is null", source);
+        }
+
+        var matcher = pattern.matcher(source);
+        if (!matcher.matches()) {
+            throw new AnnotationPropertyIsInvalid("value is not valid", source);
+        }
+
+        var prefix = matcher.group(1);
+        if (prefix == null) {
+            prefix = "";
+        } else {
+            if (prefix.length() > 254) {
+                throw new AnnotationPropertyIsInvalid("prefix is too long", source);
+            }
+            if (prefix.equals("k8s.io/") || prefix.equals("kubernetes.io/")) {
+                throw new AnnotationPropertyIsInvalid("prefix is reserved for Kubernetes core components", source);
+            }
+        }
+        
+        var name = matcher.group(2);
+        if (name == null || name.length() < 1) {
+            throw new AnnotationPropertyIsInvalid("name is required", source);
+        }
+        if (name.length() > 63) {
+            throw new AnnotationPropertyIsInvalid("name is too long", source);
+        }
+
+        var value = matcher.group(4);
+        if (value == null) {
+            value = "";
+        }
+
+        return new Annotation(prefix+name, value);
+    }
+    
+}

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/AnnotationPropertyIsInvalid.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/AnnotationPropertyIsInvalid.java
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.properties.converters;
+
+/**
+ * The exception that gets thrown when trying to convert an invalid Annotation specifier string from a property using the {@link AnnotationConverter}.
+ */
+public class AnnotationPropertyIsInvalid extends IllegalArgumentException {
+    private static final long serialVersionUID = -5499474418037813544L;
+
+    /**
+     * Initializes a new instance of the {@link AnnotationPropertyIsInvalid} class.
+     * @param reason A {@link String} describing the reason why the value is not valid.
+     * @param value The {@link String} that was provided to the converter.
+     */
+    public AnnotationPropertyIsInvalid(String reason, String value) {
+        super(String.format("Could not convert \"%s\" to an Annotation because %s. A valid string should be on the format \"key[:value]\" where a valid key is described here https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set, and the optional value can be any string.", value, reason));
+    }
+}

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/PathConverter.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/PathConverter.java
@@ -1,0 +1,36 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.properties.converters;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import io.dolittle.moose.kubernetes.ingresses.Ingress.Path;
+
+/**
+ * A Spring {@link Converter} that converts {@link String} property values to
+ * {@link Annotation}.
+ */
+@Component
+@ConfigurationPropertiesBinding
+public class PathConverter implements Converter<String, Path> {
+    private static Predicate<String> validator = Pattern.compile("^(?:\\/(?:[a-zA-Z0-9$\\-_\\.\\+]|%[a-fA-F0-9]{2})*)+$").asPredicate();
+
+    @Override
+    public Path convert(String source) {
+        if (source == null) {
+            throw new PathPropertyIsInvalid("value is null", source);
+        }
+
+        if (!validator.test(source)) {
+            throw new PathPropertyIsInvalid("value is not a valid path", source);
+        }
+
+        return new Path(source);
+    }    
+}

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/PathPropertyIsInvalid.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/converters/PathPropertyIsInvalid.java
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.properties.converters;
+
+/**
+ * The exception that gets thrown when trying to convert an invalid Path specifier string from a property using the {@link PathConverter}.
+ */
+public class PathPropertyIsInvalid extends IllegalArgumentException {
+    private static final long serialVersionUID = 6912291605328230343L;
+
+    /**
+     * Initializes a new instance of the {@link PathPropertyIsInvalid} class.
+     * @param reason A {@link String} describing the reason why the value is not valid.
+     * @param value  The {@link String} that was provided to the converter.
+     */
+    public PathPropertyIsInvalid(String reason, String value) {
+        super(String.format("Could not convert \"%s\" to a Path because %s", value, reason));
+    }
+}

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/ping/PingIngressProperties.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/ping/PingIngressProperties.java
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package io.dolittle.moose.common.properties.ping;
 
 import io.dolittle.moose.kubernetes.Annotation;

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/ping/PingIngressProperties.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/ping/PingIngressProperties.java
@@ -4,8 +4,11 @@ import io.dolittle.moose.kubernetes.Annotation;
 import io.dolittle.moose.kubernetes.ingresses.Ingress.Path;
 import lombok.Value;
 
+/**
+ * Defines the configuration for the Ingresses that will be created to route HTTP ping requests back to Moose.
+ */
 @Value
-public class PingProperties {
+public class PingIngressProperties {
     private final Annotation annotation;
     private final Path path;
 }

--- a/Source/Common/src/main/java/io/dolittle/moose/common/properties/ping/PingProperties.java
+++ b/Source/Common/src/main/java/io/dolittle/moose/common/properties/ping/PingProperties.java
@@ -1,0 +1,11 @@
+package io.dolittle.moose.common.properties.ping;
+
+import io.dolittle.moose.kubernetes.Annotation;
+import io.dolittle.moose.kubernetes.ingresses.Ingress.Path;
+import lombok.Value;
+
+@Value
+public class PingProperties {
+    private final Annotation annotation;
+    private final Path path;
+}

--- a/Source/Common/src/main/resources/common.properties
+++ b/Source/Common/src/main/resources/common.properties
@@ -1,0 +1,5 @@
+# Copyright (c) Dolittle. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+io.dolittle.moose.ping.annotation=dolittle.io/moose
+io.dolittle.moose.ping.path=/dolittle/ingress/ping

--- a/Source/Common/src/test/java/io/dolittle/moose/common/Catch.java
+++ b/Source/Common/src/test/java/io/dolittle/moose/common/Catch.java
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common;
+
+/**
+ * A simple helper class to allow writing specifications that expects exceptions to be thrown.
+ */
+public class Catch {
+    /**
+     * Runs the given expression and returns any thrown exception.
+     * @param expression The {@link Runnable} expression to run.
+     * @return An {@link Exception} if one was thrown during execution of the expression, otherwise {@literal null}.
+     */
+    public static Exception exception(Runnable expression) {
+        try {
+            expression.run();
+            return null;
+        } catch (Exception ex) {
+            return ex;
+        }
+    }
+}

--- a/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_AnnotationConverter/when_converting_invalid_strings.java
+++ b/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_AnnotationConverter/when_converting_invalid_strings.java
@@ -1,0 +1,76 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.converters.for_AnnotationConverter;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import org.junit.runner.RunWith;
+
+import info.javaspec.dsl.Because;
+import info.javaspec.dsl.Establish;
+import info.javaspec.dsl.It;
+import info.javaspec.runner.JavaSpecRunner;
+import io.dolittle.moose.common.Catch;
+import io.dolittle.moose.common.properties.converters.AnnotationConverter;
+import io.dolittle.moose.common.properties.converters.AnnotationPropertyIsInvalid;
+
+@RunWith(JavaSpecRunner.class)
+public class when_converting_invalid_strings {
+    private AnnotationConverter converter;
+    private Exception exception;
+
+    Establish context = () -> {
+        converter = new AnnotationConverter();
+        exception = null;
+    };
+
+    class when_converting_null {
+        Because of = () -> exception = Catch.exception(() -> converter.convert(null));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_empty_string {
+        Because of = () -> exception = Catch.exception(() -> converter.convert(""));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_with_k8sio_prefix {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("k8s.io/annotation"));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_with_kubernetesio_prefix {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("kubernetes.io/annotation:value"));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_without_name {
+        Because of = () -> exception = Catch.exception(() -> converter.convert(":value"));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_with_prefix_but_without_name {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("dolittle.io/:value"));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_with_a_really_long_prefix {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("lorem.ipsum.dolor.sit.amet.consectetur.adipiscing.elit.pellentesque.nec.ipsum.at.eros.pellentesque.tincidunt.mauris.vel.volutpat.sapien.nec.pharetra.est.integer.porttitor.eu.quam.non.pharetra.integer.ex.ligula.eleifend.vitae.odio.quis.ornare.vehicula.dolor/annotation"));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+
+    class when_converting_with_a_really_long_name {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("TheQuickBrownFoxJumpsOverTheLazyDogThenTripsAndFallsOverInAFunnyWay:value"));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(AnnotationPropertyIsInvalid.class));
+    }
+}

--- a/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_AnnotationConverter/when_converting_valid_strings.java
+++ b/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_AnnotationConverter/when_converting_valid_strings.java
@@ -1,0 +1,51 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.converters.for_AnnotationConverter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.runner.RunWith;
+
+import info.javaspec.dsl.Because;
+import info.javaspec.dsl.Establish;
+import info.javaspec.dsl.It;
+import info.javaspec.runner.JavaSpecRunner;
+import io.dolittle.moose.common.properties.converters.AnnotationConverter;
+import io.dolittle.moose.kubernetes.Annotation;
+
+@RunWith(JavaSpecRunner.class)
+public class when_converting_valid_strings {
+    private AnnotationConverter converter;
+    private Annotation converted;
+
+    Establish context = () -> converter = new AnnotationConverter();
+
+    class when_converting_with_name {
+        Because of = () -> converted = converter.convert("hawking");
+
+        It should_have_the_name_as_key = () -> assertEquals("hawking", converted.getKey());
+        It should_have_an_empty_value = () -> assertEquals("", converted.getValue());
+    }
+
+    class when_converting_with_prefix_and_name {
+        Because of = () -> converted = converter.convert("stephen.io/hawking");
+
+        It should_have_the_name_as_key = () -> assertEquals("stephen.io/hawking", converted.getKey());
+        It should_have_an_empty_value = () -> assertEquals("", converted.getValue());
+    }
+
+    class when_converting_with_name_and_value {
+        Because of = () -> converted = converter.convert("hawking:radiation");
+
+        It should_have_the_name_as_key = () -> assertEquals("hawking", converted.getKey());
+        It should_have_an_empty_value = () -> assertEquals("radiation", converted.getValue());
+    }
+
+    class when_converting_with_everything {
+        Because of = () -> converted = converter.convert("stephen.io/hawking:radiation");
+
+        It should_have_the_name_as_key = () -> assertEquals("stephen.io/hawking", converted.getKey());
+        It should_have_an_empty_value = () -> assertEquals("radiation", converted.getValue());
+    }
+}

--- a/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_PathConverter/when_converting_invalid_strings.java
+++ b/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_PathConverter/when_converting_invalid_strings.java
@@ -1,0 +1,52 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.converters.for_PathConverter;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+import org.junit.runner.RunWith;
+
+import info.javaspec.dsl.Because;
+import info.javaspec.dsl.Establish;
+import info.javaspec.dsl.It;
+import info.javaspec.runner.JavaSpecRunner;
+import io.dolittle.moose.common.Catch;
+import io.dolittle.moose.common.properties.converters.PathConverter;
+import io.dolittle.moose.common.properties.converters.PathPropertyIsInvalid;
+
+@RunWith(JavaSpecRunner.class)
+public class when_converting_invalid_strings {
+    private PathConverter converter;
+    private Exception exception;
+
+    Establish context = () -> {
+        converter = new PathConverter();
+        exception = null;
+    };
+
+    class when_converting_a_null {
+        Because of = () -> exception = Catch.exception(() -> converter.convert(null));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(PathPropertyIsInvalid.class));
+    }
+
+    class when_converting_an_empty_string {
+        Because of = () -> exception = Catch.exception(() -> converter.convert(""));
+
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(PathPropertyIsInvalid.class));
+    }
+    
+    class when_converting_a_full_url {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("http://dolittle.io/ping"));
+    
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(PathPropertyIsInvalid.class));
+    }
+
+    class when_converting_a_string_without_the_leading_slash {
+        Because of = () -> exception = Catch.exception(() -> converter.convert("ping/path"));
+    
+        It should_throw_an_exception = () -> assertThat(exception, instanceOf(PathPropertyIsInvalid.class));
+    }
+}

--- a/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_PathConverter/when_converting_valid_strings.java
+++ b/Source/Common/src/test/java/io/dolittle/moose/common/converters/for_PathConverter/when_converting_valid_strings.java
@@ -1,0 +1,41 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package io.dolittle.moose.common.converters.for_PathConverter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.runner.RunWith;
+
+import info.javaspec.dsl.Because;
+import info.javaspec.dsl.Establish;
+import info.javaspec.dsl.It;
+import info.javaspec.runner.JavaSpecRunner;
+import io.dolittle.moose.common.properties.converters.PathConverter;
+import io.dolittle.moose.kubernetes.ingresses.Ingress.Path;
+
+@RunWith(JavaSpecRunner.class)
+public class when_converting_valid_strings {
+    private PathConverter converter;
+    private Path converted;
+
+    Establish context = () -> converter = new PathConverter();
+
+    class when_converting_a_simple_path {
+        Because of = () -> converted = converter.convert("/dolittle");
+
+        It should_have_the_right_value = () -> assertEquals("/dolittle", converted.getValue());
+    }
+
+    class when_converting_a_longer_path {
+        Because of = () -> converted = converter.convert("/dolittle/moose/io");
+
+        It should_have_the_right_value = () -> assertEquals("/dolittle/moose/io", converted.getValue());
+    }
+
+    class when_converting_a_path_with_escaped_characters {
+        Because of = () -> converted = converter.convert("/dolittle%20moose/io");
+
+        It should_have_the_right_value = () -> assertEquals("/dolittle%20moose/io", converted.getValue());
+    }
+}

--- a/Source/Controller/pom.xml
+++ b/Source/Controller/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dolittle.moose</groupId>
         <artifactId>moose-parent</artifactId>
-        <version>0.0.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/Source/Controller/pom.xml
+++ b/Source/Controller/pom.xml
@@ -11,6 +11,8 @@
     </parent>
 
     <artifactId>moose-controller</artifactId>
+    <name>Moose Controller</name>
+    <description>The Kubernetes Controller that watches Kubernetes for Ingresses that should be monitored, and configures the Cluster to allow the Moose Pinger to perform its dutys.</description>
 
     <dependencies>
         <dependency>

--- a/Source/Controller/src/main/java/io/dolittle/moose/controller/ControllerProperties.java
+++ b/Source/Controller/src/main/java/io/dolittle/moose/controller/ControllerProperties.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
 import io.dolittle.moose.common.properties.CommonProperties;
-import io.dolittle.moose.common.properties.ping.PingProperties;
+import io.dolittle.moose.common.properties.ping.PingIngressProperties;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
@@ -14,7 +14,7 @@ import lombok.Value;
 @ConstructorBinding
 public class ControllerProperties extends CommonProperties {
     
-    public ControllerProperties(PingProperties ping) {
+    public ControllerProperties(PingIngressProperties ping) {
         super(ping);
     }
 }

--- a/Source/Controller/src/main/java/io/dolittle/moose/controller/ControllerProperties.java
+++ b/Source/Controller/src/main/java/io/dolittle/moose/controller/ControllerProperties.java
@@ -1,0 +1,20 @@
+package io.dolittle.moose.controller;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import io.dolittle.moose.common.properties.CommonProperties;
+import io.dolittle.moose.common.properties.ping.PingProperties;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ConfigurationProperties(prefix = "io.dolittle.moose")
+@ConstructorBinding
+public class ControllerProperties extends CommonProperties {
+    
+    public ControllerProperties(PingProperties ping) {
+        super(ping);
+    }
+}

--- a/Source/Controller/src/main/java/io/dolittle/moose/controller/config/ControllerConfig.java
+++ b/Source/Controller/src/main/java/io/dolittle/moose/controller/config/ControllerConfig.java
@@ -11,8 +11,8 @@ import org.springframework.context.annotation.PropertySource;
 
 @Profile("controller")
 @Configuration
-@ComponentScan(basePackages = {"io.dolittle.moose.controller", "io.dolittle.moose.kubernetes.config"})
-@ConfigurationPropertiesScan(basePackages = {"io.dolittle.moose.controller.properties"})
+@ComponentScan(basePackages = {"io.dolittle.moose.controller", "io.dolittle.moose.common.config"})
+@ConfigurationPropertiesScan(basePackages = {"io.dolittle.moose.controller"})
 @PropertySource(value = {"classpath:controller.properties"})
 public class ControllerConfig {
 

--- a/Source/Kubernetes/pom.xml
+++ b/Source/Kubernetes/pom.xml
@@ -10,6 +10,8 @@
     </parent>
 
     <artifactId>moose-kubernetes</artifactId>
+    <name>Moose Kubernetes Interactions</name>
+    <description>Wrappers for APIs and Types that the other Moose Modules use to interact with the Kubernetes Cluster.</description>
 
     <dependencies>
         <dependency>

--- a/Source/Kubernetes/pom.xml
+++ b/Source/Kubernetes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dolittle.moose</groupId>
         <artifactId>moose-parent</artifactId>
-        <version>0.0.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/Source/Kubernetes/src/test/java/io/dolittle/moose/kubernetes/errors/for_ApiExceptions.java
+++ b/Source/Kubernetes/src/test/java/io/dolittle/moose/kubernetes/errors/for_ApiExceptions.java
@@ -1,3 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package io.dolittle.moose.kubernetes.errors;
 
 import static org.junit.Assert.assertEquals;

--- a/Source/Pinger/pom.xml
+++ b/Source/Pinger/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dolittle.moose</groupId>
         <artifactId>moose-parent</artifactId>
-        <version>0.0.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/Source/Pinger/pom.xml
+++ b/Source/Pinger/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>io.dolittle.moose</groupId>
-            <artifactId>moose-kubernetes</artifactId>
+            <artifactId>moose-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/Source/Pinger/pom.xml
+++ b/Source/Pinger/pom.xml
@@ -11,6 +11,8 @@
     </parent>
 
     <artifactId>moose-pinger</artifactId>
+    <name>Moose Pinger</name>
+    <description>An HTTP pinger sends HTTP requests to a specific path that is routed to itself, to ensure that your surrounding infrastructure (networks, IP addresses, DNS...) is correctly configured to serve the configured hostnames.</description>
 
     <dependencies>
         <dependency>

--- a/Source/Runner/pom.xml
+++ b/Source/Runner/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.dolittle.moose</groupId>
         <artifactId>moose-parent</artifactId>
-        <version>0.0.1</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/Source/Runner/pom.xml
+++ b/Source/Runner/pom.xml
@@ -11,6 +11,8 @@
     </parent>
 
     <artifactId>moose-runner</artifactId>
+    <name>Moose Runner</name>
+    <description>The Moose runtime that starts all or selected Moose components based on the provided configuration.</description>
     
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>6.0.16.Final</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,14 @@
     <description>Application suite to monitor Kubernetes ingress</description>
     <packaging>pom</packaging>
 
+    <modules>
+        <module>Source/Kubernetes</module>
+        <module>Source/Common</module>
+        <module>Source/Controller</module>
+        <module>Source/Pinger</module>
+        <module>Source/Runner</module>
+    </modules>
+
     <url>https://github.com/dolittle-platform/Moose</url>
     <organization>
         <name>Dolittle</name>
@@ -48,13 +56,6 @@
     <properties>
         <java.version>11</java.version>
     </properties>
-
-    <modules>
-        <module>Source/Kubernetes</module>
-        <module>Source/Controller</module>
-        <module>Source/Pinger</module>
-        <module>Source/Runner</module>
-    </modules>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>moose-parent</artifactId>
     <version>${revision}</version>
     <name>Moose</name>
-    <description>Application suite to monitor Kubernetes ingress</description>
+    <description>Application suite to monitor Ingresses in a Kubernetes Cluster. It performs health-checks and security scans to ensure that your cluster and surrounding infrastructure is correctly and securely configured.</description>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,14 @@
         <relativePath/>
     </parent>
 
+    <properties>
+        <java.version>11</java.version>
+        <revision>0.0.1</revision>
+    </properties>
+
     <groupId>io.dolittle.moose</groupId>
     <artifactId>moose-parent</artifactId>
-    <version>0.0.1</version>
+    <version>${revision}</version>
     <name>Moose</name>
     <description>Application suite to monitor Kubernetes ingress</description>
     <packaging>pom</packaging>
@@ -52,10 +57,6 @@
         <system>GitHub</system>
         <url>https://github.com/dolittle-platform/Moose/issues</url>
     </issueManagement>
-
-    <properties>
-        <java.version>11</java.version>
-    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
- A separate module for common things shared between Pinger and Controller (right now just properties).
- Spring Converters for parsing `Annotation` and `Path` directly from `String` properties.
- Using `revision` to more easily specify the same version for all modules when building (see https://maven.apache.org/maven-ci-friendly.html).
- Added some names and descriptions to all poms.